### PR TITLE
Add interactive investigation phase with updated suspect clues

### DIFF
--- a/client/src/pages/briefing-room.tsx
+++ b/client/src/pages/briefing-room.tsx
@@ -1,192 +1,151 @@
-export default function BriefingRoomPage() {
+import { useState } from "react";
+
+interface Suspect {
+  id: string;
+  name: string;
+  background: string;
+  clues: string[];
+}
+
+const suspects: Suspect[] = [
+  {
+    id: "evelyn",
+    name: "Evelyn Steele — Spouse (trial separation)",
+    background:
+      "Interior designer. Married to Graham; on a week-long trial separation while she wrestles with suspected infidelity. Tends to monitor and control when anxious; arguments lately mixed trust + estate/beneficiary issues.",
+    clues: [
+      "Patterned surveillance drives: ALPR + neighborhood cams log six late-night passes over 3 weeks, including two loops the night before.",
+      "Spare-key access plan: Locksmith invoice (3 months ago) shows she commissioned a copy of the patio slider key; smart-lock history shows manual latch opens on two prior nights at odd hours.",
+      "Burner \"watcher\" account: A no-posts IG/TikTok handle (tied to her recovery phone) follows Cath + mutuals and saves geo-tagged posts near Graham’s street on dates matching the drive-bys.",
+      "\"Evidence box\" in trunk: Shoebox marked \"Keep\" with prenup/bank printouts and night photos of the house taken from the street (printed, dated).",
+      "Housekeeper pretext call: She phoned the housekeeper from an alternate number asking about cleaning start times and \"which doors you leave latched in the morning\" two days before the murder.",
+      "Sister-condo trail: Fob + lobby cams place her 8:47 p.m. → ~9:20 a.m. (murder night).",
+      "Phone stays put: Her phone connects to sister’s Wi-Fi all night; no motion until morning.",
+      "Bar receipt context: \"Two glasses\" receipt is two nights earlier at an unusual bar for Graham; bartender can’t ID Evelyn—suggests suspicion, not placement.",
+    ],
+  },
+  {
+    id: "priya",
+    name: "Priya Nayar — Business partner (COO)",
+    background:
+      "Co-founder/COO at Steele & Nayar. Brilliant, exacting, and politically savvy. Relationship with Graham has soured over power/strategy; an equity re-cut and possible exit were on the table.",
+    clues: [
+      "Friday blow-up: Multiple employees report a shouting match about equity/control; Priya said, ‘Not after everything I built.’",
+      "Trip canceled to stay in the fight: She canceled her annual camping trip hours after the argument, texting ‘can’t leave this hanging.’",
+      "Physical severance draft: A printed severance with her handwritten redlines (equity/role reduced) is found in Graham’s briefcase.",
+      "Message suppression: Deleted Slack DMs recovered: ‘we need to move before Monday.’ (Context unclear but time-critical.)",
+      "Morning proximity enablement: Badge at 7:02 a.m. (garage in/out) + VPN access 6:18 a.m. to financials; leaves a small window to be near Larchmont by ~7:30.",
+      "Live alibi window: 6:30–7:30 a.m. video call with an overseas supplier (mentions screen share), aligning with VPN logs.",
+      "HR pause: Documented HR email shows all role changes paused pending legal review—undercuts an ‘imminent ouster’ narrative.",
+      "Home IP footprint: The 6:18 a.m. VPN login resolves to her home IP across town, not a mobile hotspot near the scene.",
+    ],
+  },
+  {
+    id: "marco",
+    name: "Marco Flores — Former landscape contractor",
+    background:
+      "Knew the Steele family since Graham was a kid; took pride in the property. Recently fired after cost-cutting. Quick temper, fiercely loyal until he feels disrespected.",
+    clues: [
+      "Back-gate know-how: Service gate left propped with his signature wooden wedge; the camera covering that gate was unplugged the previous afternoon (he serviced that zone that day).",
+      "Boot-print & soil match: Partial work-boot print by the patio; soil residue matches his slow-release fertilizer blend.",
+      "Access exploit: The old remote gate opener (supposedly returned) pings the system at 6:12 a.m. murder morning—someone used a device linked to Marco’s former serial.",
+      "Anger trail: Texts to his foreman after the firing: ‘He’ll regret this’ + dropped map pin for the side gate.",
+      "How-to searches: His phone history shows YouTube/Google queries on disabling backyard cams and ‘bypass ring power’ the day before.",
+      "Partner alibi + meter: Partner places him home from 9 p.m.; smart-meter spike ~6:00 a.m. consistent with using power tools in his garage.",
+      "No blood on tools: Missing pruning shears found downstream show plant residue only, no blood.",
+      "Footwear mismatch: Tread wear in the print doesn’t match his current boots (points to an older pair not yet found).",
+    ],
+  },
+];
+
+function PhaseChain({ phases, current }: { phases: string[]; current: number }) {
   return (
-    <div className="min-h-screen bg-white text-gray-900">
-      <div className="max-w-3xl mx-auto p-6 space-y-8">
-        <header className="border-b-4 border-red-600 pb-4">
-          <h1 className="text-3xl font-bold">Briefing Room</h1>
+    <div className="flex space-x-2 mb-6">
+      {phases.map((phase, idx) => (
+        <div
+          key={phase}
+          className={`px-4 py-2 rounded-full text-sm font-medium border ${
+            idx === current ? "bg-red-600 text-white border-red-600" : "bg-gray-200 text-gray-700 border-gray-200"
+          }`}
+        >
+          {phase}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function BriefingRoomPage() {
+  const phases = ["Investigation"];
+  const [phaseIdx, setPhaseIdx] = useState(-1);
+  const [hours, setHours] = useState(12);
+  const [revealed, setRevealed] = useState<Record<string, number[]>>({
+    evelyn: [],
+    priya: [],
+    marco: [],
+  });
+
+  const handleBegin = () => setPhaseIdx(0);
+
+  const handleInvestigate = (id: string) => {
+    if (hours <= 0) return;
+    const suspect = suspects.find((s) => s.id === id);
+    if (!suspect) return;
+    const used = revealed[id];
+    if (used.length >= suspect.clues.length) return;
+    const remaining = suspect.clues
+      .map((_, idx) => idx)
+      .filter((idx) => !used.includes(idx));
+    const nextIdx = remaining[Math.floor(Math.random() * remaining.length)];
+    setRevealed({ ...revealed, [id]: [...used, nextIdx] });
+    setHours(hours - 1);
+  };
+
+  if (phaseIdx === -1) {
+    return (
+      <div className="min-h-screen bg-white text-gray-900 p-8">
+        <header className="border-b-4 border-red-600 pb-4 mb-8">
+          <h1 className="text-4xl font-bold">Briefing Room</h1>
         </header>
+        <div className="flex justify-center">
+          <button onClick={handleBegin} className="px-6 py-3 bg-red-600 text-white rounded-md">
+            Begin
+          </button>
+        </div>
+      </div>
+    );
+  }
 
-        <nav>
-          <ul className="flex space-x-4 text-blue-600 underline">
-            <li>
-              <a href="#watch">Watch Briefing</a>
-            </li>
-            <li>
-              <a href="#victim">Victim Information</a>
-            </li>
-            <li>
-              <a href="#suspects">Suspect Profiles</a>
-            </li>
-          </ul>
-        </nav>
-
-        <section id="watch" className="space-y-4">
-          <h2 className="text-xl font-semibold text-red-700">Watch Briefing</h2>
-          <div className="aspect-video">
-            <iframe
-              className="w-full h-full"
-              src="https://www.youtube.com/embed/dQw4w9WgXcQ"
-              title="Briefing Video"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowFullScreen
-            ></iframe>
-          </div>
-        </section>
-
-        <section id="victim" className="space-y-4">
-          <h2 className="text-xl font-semibold text-red-700">Victim Information</h2>
-          <div className="space-y-2 text-sm">
-            <p>
-              <strong>Graham Steele — The Victim</strong>
-            </p>
-            <ul className="list-disc ml-5 space-y-1">
-              <li>Age: 39</li>
-              <li>
-                Occupation: CEO and co‑founder of boutique design firm “Steele & Nayar.”
-              </li>
-              <li>
-                Relationships: In a trial separation; friends aware Evelyn suspected infidelity but couldn’t prove it; professional partner with Priya; employed Marco until recently; secret affair with Cath.
-              </li>
-              <li>
-                Last 48 Hours: Firing dispute with Marco; heated strategy call with Priya; late dinner at home with a guest; texted a friend about “needing to talk to Evelyn this weekend.” Found murdered in his bedroom the next morning.
-              </li>
-              <li>
-                Complications: Updated will in Evelyn’s favor; considering restructuring that could dilute Priya; planned to rehire a cheaper landscaping crew.
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        <section id="suspects" className="space-y-6">
-          <h2 className="text-xl font-semibold text-red-700">Suspect Profiles</h2>
-
-          <article className="space-y-2">
-            <h3 className="text-lg font-bold">Evelyn Steele — Spouse (Trial Separation)</h3>
-            <ul className="list-disc ml-5 space-y-1 text-sm">
-              <li>
-                <strong>Relationship to victim:</strong> Wife; staying with her sister this week during a brief separation.
-              </li>
-              <li>
-                <strong>Background:</strong> Interior designer; suspected his infidelity and monitored his routines.
-              </li>
-              <li>
-                <strong>Motive snapshot:</strong> Betrayal + financial/estate tensions (beneficiary/prenup context).
-              </li>
-              <li>
-                <strong>Behavior of concern (documented):</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>
-                    Late-night drive-bys: ALPR + neighborhood cams log six passes in 3 weeks (two loops night before).
-                  </li>
-                  <li>
-                    Access history: Locksmith invoice for copied patio slider key; smart-lock shows manual latch opens on two earlier nights.
-                  </li>
-                  <li>
-                    Burner “watcher” social account follows you + mutuals; saved posts geo-tagged near his street on dates matching drive-bys.
-                  </li>
-                  <li>
-                    Trunk “Keep” box: prenup/bank printouts + night photos of the house from the street.
-                  </li>
-                </ul>
-              </li>
-              <li>
-                <strong>Counterpoints / alibi anchors:</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>Sister’s condo fob + cameras: 8:47 p.m. → ~9:20 a.m. (night of).</li>
-                  <li>Bar receipt with “two glasses” is two nights earlier; bartender can’t ID her.</li>
-                  <li>Spousal key access is lawful; none of the photos are from the murder morning.</li>
-                </ul>
-              </li>
-              <li>
-                <strong>What to press (questions):</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>“Purpose of the drive-bys? Why two loops last night?”</li>
-                  <li>“Who else knows about the spare key? When last used?”</li>
-                  <li>“Why follow Cath and mutuals from a burner? What were you watching for?”</li>
-                </ul>
-              </li>
-            </ul>
-          </article>
-
-          <article className="space-y-2">
-            <h3 className="text-lg font-bold">Marco Flores — Former Landscape Contractor</h3>
-            <ul className="list-disc ml-5 space-y-1 text-sm">
-              <li>
-                <strong>Relationship to victim:</strong> Long-time gardener; recently fired after years of service.
-              </li>
-              <li>
-                <strong>Background:</strong> Known quick temper (recently smashed a tool in anger); minor, non-violent run-ins with the law years back; historically loyal to the Steele family since Graham was a kid.
-              </li>
-              <li>
-                <strong>Motive snapshot:</strong> Resentment over termination; pride + perceived injustice.
-              </li>
-              <li>
-                <strong>Opportunity indicators:</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>Muddy boot print near back patio; soil traces match his fertilizer blend.</li>
-                  <li>
-                    Service gate propped with his signature wooden wedge; camera covering that gate found unplugged earlier.
-                  </li>
-                  <li>Old remote gate opener (returned) pinged at 6:12 a.m. murder morning.</li>
-                </ul>
-              </li>
-              <li>
-                <strong>Counterpoints / alibi anchors:</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>Partner alibi: Home from 9 p.m.; smart-meter shows tool use ~6 a.m.</li>
-                  <li>Boot print wear pattern doesn’t match his current boots (older pair?).</li>
-                </ul>
-              </li>
-              <li>
-                <strong>What to press (questions):</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>“Explain the 6:12 a.m. gate ping.”</li>
-                  <li>“Where are your older boots? Can we see them?”</li>
-                  <li>“Who knew your wedge trick? Anyone else could copy it?”</li>
-                </ul>
-              </li>
-            </ul>
-          </article>
-
-          <article className="space-y-2">
-            <h3 className="text-lg font-bold">Priya Nayar — Business Partner (COO)</h3>
-            <ul className="list-disc ml-5 space-y-1 text-sm">
-              <li>
-                <strong>Relationship to victim:</strong> Co-founder at Steele & Nayar.
-              </li>
-              <li>
-                <strong>Background:</strong> High-stakes week; Friday blow-up at the office (witnessed); canceled annual camping trip right after.
-              </li>
-              <li>
-                <strong>Motive snapshot:</strong> Draft severance with her handwritten edits; risk to equity/reputation; Board “Role Change” meeting slated for the next morning.
-              </li>
-              <li>
-                <strong>Opportunity indicators:</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>
-                    VPN access at 6:18 a.m. to firm financials; garage badge at 7:02 a.m. (could reach the house by ~7:30).
-                  </li>
-                  <li>Severance draft found in victim’s briefcase with her redline handwriting.</li>
-                </ul>
-              </li>
-              <li>
-                <strong>Counterpoints / alibi anchors:</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>6:30–7:30 a.m. video call with overseas supplier (mentions screen share), aligning with VPN.</li>
-                  <li>HR email shows role changes paused pending legal review.</li>
-                </ul>
-              </li>
-              <li>
-                <strong>What to press (questions):</strong>
-                <ul className="list-disc ml-5 space-y-1">
-                  <li>“When and where did you last handle that physical severance draft?”</li>
-                  <li>“Why cancel the camping trip immediately after the argument?”</li>
-                  <li>“Walk the exact 6:00–8:00 a.m. timeline—devices, calls, location.”</li>
-                </ul>
-              </li>
-            </ul>
-          </article>
-        </section>
+  return (
+    <div className="min-h-screen bg-white text-gray-900 p-8">
+      <header className="border-b-4 border-red-600 pb-4 mb-6">
+        <h1 className="text-4xl font-bold">Briefing Room</h1>
+      </header>
+      <PhaseChain phases={phases} current={phaseIdx} />
+      <div className="mb-4 font-semibold">Hours Remaining: {hours}</div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {suspects.map((s) => {
+          const used = revealed[s.id];
+          const allRevealed = used.length >= s.clues.length;
+          return (
+            <div key={s.id} className="border p-4 rounded-md space-y-2">
+              <h2 className="text-lg font-bold">{s.name}</h2>
+              <p className="text-sm">{s.background}</p>
+              <button
+                onClick={() => handleInvestigate(s.id)}
+                disabled={hours <= 0 || allRevealed}
+                className="px-2 py-1 bg-blue-600 text-white rounded disabled:bg-gray-400"
+              >
+                Spend 1 hour
+              </button>
+              <ul className="list-disc ml-4 text-sm space-y-1">
+                {used.map((i) => (
+                  <li key={i}>{s.clues[i]}</li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- overhaul briefing room into an investigation flow with a begin button
- track 12 investigation hours and reveal random clues for each suspect
- update suspect profiles with new backgrounds and eight clues each

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68ad20996e048331acec74e6eba4e840