### PR TITLE
Add police chief consultation and suspect elimination flow

### DIFF
--- a/client/src/pages/briefing-room.tsx
+++ b/client/src/pages/briefing-room.tsx
@@ -84,6 +84,9 @@ export default function BriefingRoomPage() {
     priya: [],
     marco: [],
   });
+  const [chiefConsulted, setChiefConsulted] = useState(false);
+  const [chiefMessage, setChiefMessage] = useState("");
+  const [eliminated, setEliminated] = useState<string | null>(null);
 
   const handleBegin = () => setPhaseIdx(0);
 
@@ -101,6 +104,14 @@ export default function BriefingRoomPage() {
     setHours(hours - 1);
   };
 
+  const handleChief = () => {
+    setChiefConsulted(true);
+    setChiefMessage(
+      'Duty Chief Vega: "Hmm good start, but it\'s not enough, I can give you another 6 hours, but after that I need you to eliminate at least one of these suspects so that we can focus our investigation. We don\'t have a lot of time, Cath!"'
+    );
+    setHours(4);
+  };
+
   if (phaseIdx === -1) {
     return (
       <div className="min-h-screen bg-white text-gray-900 p-8">
@@ -116,12 +127,92 @@ export default function BriefingRoomPage() {
     );
   }
 
+  if (eliminated) {
+    const eliminatedName = suspects.find((s) => s.id === eliminated)?.name;
+    return (
+      <div className="min-h-screen bg-white text-gray-900 p-8">
+        <header className="border-b-4 border-red-600 pb-4 mb-6">
+          <h1 className="text-4xl font-bold">Briefing Room</h1>
+        </header>
+        <PhaseChain phases={phases} current={phaseIdx} />
+        {chiefMessage && (
+          <div className="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded">
+            {chiefMessage}
+          </div>
+        )}
+        <div className="p-4 border rounded-md">
+          You have eliminated {eliminatedName}.
+        </div>
+      </div>
+    );
+  }
+
+  if (hours <= 0 && chiefConsulted) {
+    return (
+      <div className="min-h-screen bg-white text-gray-900 p-8">
+        <header className="border-b-4 border-red-600 pb-4 mb-6">
+          <h1 className="text-4xl font-bold">Briefing Room</h1>
+        </header>
+        <PhaseChain phases={phases} current={phaseIdx} />
+        {chiefMessage && (
+          <div className="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded">
+            {chiefMessage}
+          </div>
+        )}
+        <div className="mb-6">Select a suspect to eliminate:</div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {suspects.map((s) => {
+            const used = revealed[s.id];
+            return (
+              <div key={s.id} className="border p-4 rounded-md space-y-2">
+                <h2 className="text-lg font-bold">{s.name}</h2>
+                <p className="text-sm">{s.background}</p>
+                <button
+                  onClick={() => setEliminated(s.id)}
+                  className="px-2 py-1 bg-red-600 text-white rounded"
+                >
+                  Eliminate
+                </button>
+                <ul className="list-disc ml-4 text-sm space-y-1">
+                  {used.map((i) => (
+                    <li key={i}>{s.clues[i]}</li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  if (hours <= 0 && !chiefConsulted) {
+    return (
+      <div className="min-h-screen bg-white text-gray-900 p-8">
+        <header className="border-b-4 border-red-600 pb-4 mb-6">
+          <h1 className="text-4xl font-bold">Briefing Room</h1>
+        </header>
+        <PhaseChain phases={phases} current={phaseIdx} />
+        <div className="flex justify-center">
+          <button onClick={handleChief} className="px-6 py-3 bg-red-600 text-white rounded-md">
+            Take findings to the police chief
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-white text-gray-900 p-8">
       <header className="border-b-4 border-red-600 pb-4 mb-6">
         <h1 className="text-4xl font-bold">Briefing Room</h1>
       </header>
       <PhaseChain phases={phases} current={phaseIdx} />
+      {chiefMessage && (
+        <div className="mb-4 p-4 bg-yellow-100 border border-yellow-400 rounded">
+          {chiefMessage}
+        </div>
+      )}
       <div className="mb-4 font-semibold">Hours Remaining: {hours}</div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {suspects.map((s) => {
@@ -150,4 +241,3 @@ export default function BriefingRoomPage() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Allow players to consult Duty Chief Vega after exhausting investigation time and receive a new directive
- Reset hours and display narrative message from the chief
- Require players to eliminate a suspect once the extra time is used

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68ad2499d4b08331842c2537ef629463