### PR TITLE
Use square Vega headshot

### DIFF
--- a/client/src/pages/briefing-room.tsx
+++ b/client/src/pages/briefing-room.tsx
@@ -6,7 +6,7 @@ import scenePic from "../pics/scene.png";
 import evelynPic from "../pics/evelyn.png";
 import priyaPic from "../pics/priya.png";
 import marcoPic from "../pics/marco.png";
-import vegaPic from "../pics/vega.svg";
+import vegaPic from "../pics/vega.png";
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -239,13 +239,11 @@ export default function BriefingRoomPage() {
         </header>
         <StageBreadcrumb current={0} />
         <div className="flex flex-col md:flex-row gap-6 mb-6 items-start">
-          <AspectRatio ratio={1} className="w-24 md:w-32 shrink-0">
-            <img
-              src={vegaPic}
-              alt="Duty Chief Vega"
-              className="object-cover rounded w-full h-full"
-            />
-          </AspectRatio>
+          <img
+            src={vegaPic}
+            alt="Duty Chief Vega"
+            className="h-48 w-48 object-cover rounded shrink-0"
+          />
           <div className="space-y-4 text-sm">
             <p>
               Detective, Deputy — thanks for coming in on short notice. We’ve
@@ -330,13 +328,11 @@ export default function BriefingRoomPage() {
         <StageBreadcrumb current={stageIdx} />
         {chiefMessage && (
           <div className="mb-6 p-4 bg-yellow-100 border border-yellow-400 rounded flex gap-4 items-start">
-            <AspectRatio ratio={1} className="w-24 shrink-0">
-              <img
-                src={vegaPic}
-                alt="Duty Chief Vega"
-                className="object-cover rounded w-full h-full"
-              />
-            </AspectRatio>
+            <img
+              src={vegaPic}
+              alt="Duty Chief Vega"
+              className="h-48 w-48 object-cover rounded shrink-0"
+            />
             <p>{chiefMessage}</p>
           </div>
         )}
@@ -442,18 +438,16 @@ export default function BriefingRoomPage() {
           <h1 className="text-4xl font-bold">Briefing Room</h1>
         </header>
         <StageBreadcrumb current={stageIdx} />
-        {chiefMessage && (
-          <div className="mb-6 p-4 bg-yellow-100 border border-yellow-400 rounded flex gap-4 items-start">
-            <AspectRatio ratio={1} className="w-24 shrink-0">
-              <img
-                src={vegaPic}
-                alt="Duty Chief Vega"
-                className="object-cover rounded w-full h-full"
-              />
-            </AspectRatio>
-            <p>{chiefMessage}</p>
-          </div>
-        )}
+      {chiefMessage && (
+        <div className="mb-6 p-4 bg-yellow-100 border border-yellow-400 rounded flex gap-4 items-start">
+          <img
+            src={vegaPic}
+            alt="Duty Chief Vega"
+            className="h-48 w-48 object-cover rounded shrink-0"
+          />
+          <p>{chiefMessage}</p>
+        </div>
+      )}
         <div className="flex flex-col md:flex-row gap-6 mb-6 items-center">
           <div className="text-center">
             <img
@@ -514,13 +508,11 @@ export default function BriefingRoomPage() {
       <StageBreadcrumb current={stageIdx} />
       {chiefMessage && (
         <div className="mb-6 p-4 bg-yellow-100 border border-yellow-400 rounded flex gap-4 items-start">
-          <AspectRatio ratio={1} className="w-24 shrink-0">
-            <img
-              src={vegaPic}
-              alt="Duty Chief Vega"
-              className="object-cover rounded w-full h-full"
-            />
-          </AspectRatio>
+          <img
+            src={vegaPic}
+            alt="Duty Chief Vega"
+            className="h-48 w-48 object-cover rounded shrink-0"
+          />
           <p>{chiefMessage}</p>
         </div>
       )}

--- a/client/src/pics/vega.svg
+++ b/client/src/pics/vega.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" fill="#ddd" />
-  <circle cx="50" cy="35" r="20" fill="#c96" />
-  <rect x="25" y="60" width="50" height="30" fill="#6c757d" />
-  <text x="50" y="95" font-size="14" text-anchor="middle" fill="#333">Vega</text>
-</svg>


### PR DESCRIPTION
## Summary
- replace placeholder Vega SVG with square PNG headshot
- show Vega image at a consistent 48x48 size alongside other headshots

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b058b4f9f08331a85cde6ff3a27d92