### PR TITLE
Add noir-themed title headers

### DIFF
--- a/client/src/components/noir-title.tsx
+++ b/client/src/components/noir-title.tsx
@@ -1,0 +1,23 @@
+interface NoirTitleProps {
+  subtitle?: string;
+  small?: boolean;
+}
+
+export default function NoirTitle({ subtitle, small }: NoirTitleProps) {
+  if (small) {
+    return (
+      <div className="bg-black text-white text-center py-2 text-sm font-serif tracking-widest">
+        Only Murders in the Bedroom
+      </div>
+    );
+  }
+
+  return (
+    <header className="bg-black text-white text-center py-10 shadow-lg">
+      <h1 className="text-5xl font-serif tracking-widest">
+        Only Murders in the Bedroom
+      </h1>
+      {subtitle && <p className="text-xl mt-2 italic">{subtitle}</p>}
+    </header>
+  );
+}

--- a/client/src/pages/briefing-room.tsx
+++ b/client/src/pages/briefing-room.tsx
@@ -14,6 +14,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "../components/ui/breadcrumb";
+import NoirTitle from "@/components/noir-title";
 
 const casefileClasses =
   "bg-amber-50 border-2 border-amber-200 p-4 rounded-sm shadow-md space-y-2";
@@ -626,11 +627,13 @@ export default function BriefingRoomPage() {
   }
 
   return (
-    <div className="min-h-screen bg-white text-gray-900 p-8">
-      <header className="border-b-4 border-blue-600 pb-4 mb-6">
-        <h1 className="text-4xl font-bold">Briefing Room</h1>
-      </header>
-      <StageBreadcrumb current={stageIdx} onNavigate={setStage} />
+    <div className="min-h-screen bg-white text-gray-900">
+      <NoirTitle small />
+      <div className="p-8">
+        <header className="border-b-4 border-blue-600 pb-4 mb-6">
+          <h1 className="text-4xl font-bold">Briefing Room</h1>
+        </header>
+        <StageBreadcrumb current={stageIdx} onNavigate={setStage} />
       {chiefMessage && (
         <div className="mb-6 p-4 bg-yellow-100 border border-yellow-400 rounded flex gap-4 items-start">
           <img
@@ -687,6 +690,7 @@ export default function BriefingRoomPage() {
           );
         })}
       </div>
+    </div>
     </div>
   );
 }

--- a/client/src/pages/intro.tsx
+++ b/client/src/pages/intro.tsx
@@ -1,5 +1,6 @@
 import { Target } from "lucide-react";
 import { useLocation } from "wouter";
+import NoirTitle from "@/components/noir-title";
 
 export default function CaseFilePage() {
   const [, setLocation] = useLocation();
@@ -15,6 +16,7 @@ export default function CaseFilePage() {
 
   return (
     <div className="min-h-screen bg-white text-gray-900">
+      <NoirTitle subtitle="A night of passion… and murder." />
       <div className="max-w-2xl mx-auto p-6 space-y-8">
         <header className="border-b-4 border-blue-600 pb-4">
           <h1 className="text-3xl font-bold">CASE FILE: OMITB-001</h1>

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,21 +1,25 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertCircle } from "lucide-react";
+import NoirTitle from "@/components/noir-title";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md mx-4">
-        <CardContent className="pt-6">
-          <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-blue-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
-          </div>
+    <div className="min-h-screen w-full flex flex-col bg-gray-50">
+      <NoirTitle small />
+      <div className="flex flex-1 items-center justify-center">
+        <Card className="w-full max-w-md mx-4">
+          <CardContent className="pt-6">
+            <div className="flex mb-4 gap-2">
+              <AlertCircle className="h-8 w-8 text-blue-500" />
+              <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+            </div>
 
-          <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
-          </p>
-        </CardContent>
-      </Card>
+            <p className="mt-4 text-sm text-gray-600">
+              Did you forget to add the page to the router?
+            </p>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `NoirTitle` component for noir-styled title text
- display full noir title and subtitle on intro page
- show compact noir title on briefing room and 404 pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68b9e66af6388331b9e1fc1f67057423